### PR TITLE
Fix for bug #53272

### DIFF
--- a/CABlob.cs
+++ b/CABlob.cs
@@ -99,7 +99,7 @@ namespace Ildasm
             }
             else if (typerefs.Contains(type))
             {
-                sb.Append('[').Append(QuoteIdentifier(referencedAssemblies[type.Assembly])).Append(']');
+                sb.Append('[').Append(QuoteIdentifier(FindReferencedAssembly(type.Assembly))).Append(']');
                 AppendTypeName(sb, type);
             }
             else


### PR DESCRIPTION
In https://bugzilla.xamarin.com/show_bug.cgi?id=53272 we have an issue where ikdasm fails to disassemble certain .NET executables. In these executables some references are an assembly named "mscorlib" instead of the correct "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089". Because ikdasm does an exact lookup for references (using the Assembly object as a key) attempts to look up this reference fail and ikdasm crashes. MS's ildasm on Windows, along with other disassemblers like dnSpy, handle this correctly. The 'wrong' executables also run correctly in mono and the Windows .NET runtime.

This is a preliminary fix that switches to manually doing reference lookup using strings, and populates the lookup table with the short name(s) of the assemblies. This fixes the crash but I'm not sure it's the right solution, and there are some corner cases I'm not sure how to handle (marked with comments in the commit).